### PR TITLE
Prevent properties outside range when using `dzmax`

### DIFF
--- a/ModelGenerator/ModelGenerator.py
+++ b/ModelGenerator/ModelGenerator.py
@@ -513,7 +513,7 @@ class Stratigraphy(object):
                 gradx = gradxs[ii]
 
             for jj, prop in enumerate(lith):
-                if prop.dzmax is not None and lith0 == lith:
+                if prop.dzmax is not None and lith0 is not None:
                     minval = properties[jj] - prop.dzmax
                     maxval = properties[jj] + prop.dzmax
                     if minval < prop.min:


### PR DESCRIPTION
Force extremum values `prop.min` and `prop.max` after applying `prop.dzmax`.

Properties beyond extremum values were allowed through `minval = properties[jj] - prop.dzmax` and `maxval = properties[jj] + prop.dzmax`. This sometimes caused negative values and crashed dataset generation at line 276 of `GeoFlow.SeismicUtilities` (`vrms = np.sqrt(t0 * np.cumsum(vp**2 * delta))`).