### PR TITLE
Implement faults

### DIFF
--- a/ModelGenerator/ModelGenerator.py
+++ b/ModelGenerator/ModelGenerator.py
@@ -655,7 +655,7 @@ class Faults:
 
         x_min, x_max = self.x_lim or (0, layerids.shape[1])
         y_min, y_max = self.y_lim or (0, layerids.shape[0])
-        y = layerids.shape[1] - np.random.randint(y_min, y_max)
+        y = layerids.shape[0] - np.random.randint(y_min, y_max)
         x = np.random.randint(x_min, x_max)
 
         grid_idx = np.meshgrid(*(np.arange(s) for s in layerids.shape[::-1]))


### PR DESCRIPTION
Generate faults by randomly sampling the dip angle and displacement. Apply the faults to the gridded model.

Hi, @gfabieno! I implemented a fault generator. It's working on my end, but I'm unsure if the implementation follows the philosophy of the rest of the module. Could you have a look at it? For instance, is calling `add_faults` after `gridded_model` the right way to do it? Thank you in advance!

Here are two examples of default models with maximum displacements of 1000 meters and 30 degrees.
![image](https://user-images.githubusercontent.com/28260990/150189760-d9fc7e93-6b36-4f57-a64f-49c873fc858e.png)
![image](https://user-images.githubusercontent.com/28260990/150189814-d847938d-c948-4928-9ad6-7514698b1765.png)

🚀
